### PR TITLE
fix: correct endpoint from /list to /history

### DIFF
--- a/clientcode/station/obtain_station_history.py
+++ b/clientcode/station/obtain_station_history.py
@@ -2,7 +2,7 @@ import requests
 from clientcode import variable
 
 if __name__ == '__main__':
-    url = variable.baseurl + '/station/list'
+    url = variable.baseurl + '/station/history'
     headers = variable.headers
 
     """


### PR DESCRIPTION
The endpoint should be '/history' based on the API docs: https://developer.deyecloud.com/api

/list is used on the obtain_station_list.py endpoint.